### PR TITLE
Support encoded brackets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ function parseValue(key, val) {
 
 function parseKey(key) {
   var query = this, seq, val;
-  seq = key.split(/\[/);
+  seq = decodeURIComponent(key).split(/\[/);
   val = query[key];
   if (seq.length > 1) {
     seq.reduce(function (obj, p, i, seq) {


### PR DESCRIPTION
My trip planner URLs look like `https://trips.furkot.com/trip?stop%5bname%5d=Algonquin&amp;stop%5bcoordinates%5d%5blat%5d=45.8372&amp;stop%5bcoordinates%5d%5blon%5d=-78.3791`. The current code does not support this.
