### PR TITLE
Allow binding forms/buttons after page load

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,8 @@ var init = require('domready'),
   },
   widget, iframe, ready, deferred, styles, uid;
 
-module.exports = initWidget;
+module.exports.plan = postStops;
+module.exports.bindButtons = bindButtons;
 
 function parseValue(key, val) {
   var fn = parseMap[key];
@@ -142,7 +143,10 @@ function initButtons(fn) {
   fn();
 }
 
-function initWidget(buttons) {
+/*
+ * Initialize the Furkot widget.
+ */
+function initWidget() {
   if (!widget) {
     // find Furkot widget; add hidden if not found
     Array.prototype.some.call(document.querySelectorAll('iframe'), function (node) {
@@ -198,30 +202,33 @@ function initWidget(buttons) {
       iframe.setAttribute('src', href.widget);
     }
     if (widget) {
-      state.init(widget, buttons || []);
+      state.init(widget);
       styles = style(widget);
+      uid = dataset(widget, 'uid');
     }
-  }
-  if (widget) {
-    uid = dataset(widget, 'uid');
-    return {
-      plan: postStops
-    };
   }
 }
 
-init(function () {
+/*
+ * Bind Furkot buttons/forms in container and setup click/submit handlers.
+ */
+function bindButtons(container) {
   var id, links, forms, buttons;
 
+  if (!widget) {
+    // Not initialized for some reason. Log warning?
+    return false;
+  }
+  
   initButtons(function () {
     // find Furkot buttons
-    links = Array.prototype.reduce.call(document.links, function (links, link) {
+    links = Array.prototype.reduce.call(container.querySelectorAll('a'), function (links, link) {
       if (isFurkotLink(link)) {
         links.push(link);
       }
       return links;
     }, []);
-    forms = Array.prototype.reduce.call(document.forms, function (forms, form) {
+    forms = Array.prototype.reduce.call(container.querySelectorAll('form'), function (forms, form) {
       if (isFurkotForm(form)) {
         forms.push(form);
       }
@@ -239,10 +246,10 @@ init(function () {
         }
         return buttons;
       }, []).concat(links);
+      
+      buttons = state.addButtons(buttons);
 
-      initWidget(buttons);
-
-      if (widget) {
+      if (buttons.length > 0) {
         // register Furkot buttons
         links.forEach(function (link) {
           event.bind(link, 'click', function (e) {
@@ -261,4 +268,11 @@ init(function () {
       }
     }
   });
+
+  return true;
+}
+
+init(function() {
+  initWidget();
+  bindButtons(document);
 });

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,29 +1,45 @@
 var classes = require('classes'),
   el = require('el'),
   event = require('event'),
-  widget, buttons, done;
+  widget, buttons, done, active;
 
 module.exports = {
-    init: init,
-    activate: activate
+  init: init,
+  activate: activate,
+	addButtons: addButtons
 };
 
-function init(wdgt, bttns) {
+function init(wdgt) {
   widget = wdgt;
-  buttons = bttns;
+  buttons = [];
   doneButton(widget);
-  if (classes(widget).has('furkot-widget-active')) {
-    setActive(done);
+  active = classes(widget).has('furkot-widget-active');
+  processState();
+}
+
+/**
+ * Adds buttons to the state storage.
+ *
+ * Returns the buttons that were not present.
+ */
+function addButtons(bttns) {
+  var newButtons = bttns.filter(function(bttn) {
+    return buttons.indexOf(bttn) === -1;
+  });
+  if (newButtons.length) {
+    buttons = buttons.concat(newButtons);
+    processState();
   }
-  else {
-    setInactive(widget);
-    buttons.forEach(setInactive);
-    setInactive(done);
-  }
+  return newButtons;
 }
 
 function activate(ac) {
-  if (ac === false) {
+  active = ac !== false;
+  processState();
+}
+
+function processState() {
+  if (active === false) {
     setInactive(widget);
     buttons.forEach(setInactive);
     setInactive(done);


### PR DESCRIPTION
This changes the external interface because the module no longer exports a function but an object with the methods bindButtons and plan.
bindButtons accepts a DOM element and attaches submit/click handlers on all buttons that haven't been initialized yet.

Fixes #2 

Still TODO: binding dynamically added microdata, because I don't use it and it is a separate repository.
